### PR TITLE
Dockerfile 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+### build stage ###
+FROM gradle:7.6-jdk17 AS builder
+RUN mkdir /usr/src/app
+COPY --chown=gradle:gradle . /usr/src/app
+WORKDIR /usr/src/app
+RUN gradle build --no-daemon -x test
+
+FROM openjdk:17-alpine
+ARG JAR_FILE=/usr/src/app/build/libs/*.jar
+ENV JAVA_OPTS=""
+COPY --from=builder ${JAR_FILE} app.jar
+ENTRYPOINT java ${JAVA_OPTS} -jar /app.jar


### PR DESCRIPTION
### 💡 Issue Number

Issue #18 

### 📙 작업 내역

- Dockerfile추가

### 작업 유형

- 기능개발

### PR 특이 사항

docker-compose가 미숙해서 아직 .jar 하고 db를 묶지 못했습니다. 
일단 db는 docker-compose로 띄우고, api는 docker 싱글 컨테이너로 띄우는 방식으로 했습니다.

- [ ] docker-compose로 db, api.jar 묶기

### How to build & run
```
docker build -t api .
docker run --name dangdo-api -p 8080:8080 --network backend -t api
```